### PR TITLE
Add -fno-strict-aliasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
   CXX     := c++
   LDFLAGS := -lm -shared
 endif
-CFLAGS := -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
+CFLAGS := -fno-strict-aliasing -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio
 BUILD_DIR := build


### PR DESCRIPTION
By default libsm64 is compiled with no optimisation so this doesn't matter, but if people want optimisation this stops it from breaking. I think the issue is related to loading things from the ROM file